### PR TITLE
Add owner and bank names to transaction rows

### DIFF
--- a/generator/entities.py
+++ b/generator/entities.py
@@ -16,13 +16,17 @@ class Bank:
         self.name = name
 
 class Account:
-    def __init__(self, owner_id, owner_type, bank_id, currency="USD"):
+    def __init__(self, owner_id, owner_type, bank_id, currency="USD",
+                 owner_name=None, bank_name=None):
         self.id = str(uuid.uuid4())[:12]
         self.owner_id = owner_id
         self.owner_type = owner_type
         self.bank_id = bank_id
         self.currency = currency
         self.account_number = str(random.randint(10**9, 10**10 - 1))
+        # Optional context for downstream transaction rows
+        self.owner_name = owner_name
+        self.bank_name = bank_name
 
 # === Base Entity ===
 class Entity:
@@ -91,7 +95,9 @@ def assign_accounts(entities, banks, accounts_per_entity=(1, 3)):
                 owner_id=entity.id,
                 owner_type=entity.__class__.__name__,
                 bank_id=bank.id,
-                currency=random.choice(CURRENCIES)
+                currency=random.choice(CURRENCIES),
+                owner_name=entity.name,
+                bank_name=bank.name
             )
             entity.accounts.append(account)
             all_accounts.append(account)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -73,6 +73,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
         if src is None and tgt is not None:
             if tgt_known:
                 rows.append({
+                    "transaction_id": txn_id,
                     "entry_id": txn_id + "-C",
                     "timestamp": timestamp,
                     "account_id": tgt.id,
@@ -80,6 +81,8 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
                     "amount": abs(amount),
                     "direction": "credit",
                     "currency": currency,
+                    "bank_name": tgt.bank_name,
+                    "owner_name": tgt.owner_name,
                     "payment_type": payment_type,
                     "is_laundering": is_laundering,
                     "source_description": credit_description,
@@ -92,6 +95,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
         if tgt is None and src is not None:
             if src_known:
                 rows.append({
+                    "transaction_id": txn_id,
                     "entry_id": txn_id + "-D",
                     "timestamp": timestamp,
                     "account_id": src.id,
@@ -99,6 +103,8 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
                     "amount": -abs(amount),
                     "direction": "debit",
                     "currency": currency,
+                    "bank_name": src.bank_name,
+                    "owner_name": src.owner_name,
                     "payment_type": payment_type,
                     "is_laundering": is_laundering,
                     "source_description": debit_description,
@@ -110,6 +116,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
         # Traditional cash transfer between two accounts (rare)
         if src_known:
             rows.append({
+                "transaction_id": txn_id,
                 "entry_id": txn_id + "-D",
                 "timestamp": timestamp,
                 "account_id": src.id,
@@ -117,6 +124,8 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
                 "amount": -abs(amount),
                 "direction": "debit",
                 "currency": currency,
+                "bank_name": src.bank_name,
+                "owner_name": src.owner_name,
                 "payment_type": payment_type,
                 "is_laundering": is_laundering,
                 "source_description": debit_description,
@@ -126,6 +135,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
 
         if tgt_known:
             rows.append({
+                "transaction_id": txn_id,
                 "entry_id": txn_id + "-C",
                 "timestamp": timestamp,
                 "account_id": tgt.id,
@@ -133,6 +143,8 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
                 "amount": abs(amount),
                 "direction": "credit",
                 "currency": currency,
+                "bank_name": tgt.bank_name,
+                "owner_name": tgt.owner_name,
                 "payment_type": payment_type,
                 "is_laundering": is_laundering,
                 "source_description": credit_description,
@@ -145,6 +157,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
     # Non-cash transactions
     if src_known:
         rows.append({
+            "transaction_id": txn_id,
             "entry_id": txn_id + "-D",
             "timestamp": timestamp,
             "account_id": src.id,
@@ -152,6 +165,8 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
             "amount": -abs(amount),
             "direction": "debit",
             "currency": currency,
+            "bank_name": src.bank_name,
+            "owner_name": src.owner_name,
             "payment_type": payment_type,
             "is_laundering": is_laundering,
             "source_description": debit_description
@@ -159,6 +174,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
 
     if tgt_known:
         rows.append({
+            "transaction_id": txn_id,
             "entry_id": txn_id + "-C",
             "timestamp": timestamp,
             "account_id": tgt.id,
@@ -166,6 +182,8 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
             "amount": abs(amount),
             "direction": "credit",
             "currency": currency,
+            "bank_name": tgt.bank_name,
+            "owner_name": tgt.owner_name,
             "payment_type": payment_type,
             "is_laundering": is_laundering,
             "source_description": credit_description


### PR DESCRIPTION
## Summary
- allow `Account` to store `owner_name` and `bank_name`
- include these fields for all rows generated by `split_transaction`
- populate account metadata when assigning accounts

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python main.py --individuals 2 --companies 1 --banks 1 --legit_txns 5 --laundering_chains 0 --output /tmp/out.xlsx --format csv --known_account_ratio 1 --start_date 2025-01-01 --end_date 2025-01-05`