### PR TITLE
Add profile-driven transaction generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,12 @@ The patterns.yaml file contains the instructions for each money laundering techn
 | `start_date`, `end_date`  | Timestamp range to assign to transactions                                                           |
 | `label`                   | Whether transactions should be marked as laundering                                                 |
 
+### Agent Profiles
+If you have a structured Excel file of agent profiles, you can generate transactions based on that data:
+
+```bash
+python main.py --agent_profiles agents/agent_profiles.xlsx
+```
+
+The generator will read merchant patterns, frequencies, payment methods, and average expenses to create realistic transactions between the entities defined in the file.
+


### PR DESCRIPTION
## Summary
- implement profile-based transaction generator that reads `agent_profiles.xlsx`
- allow `main.py` to load agent profiles via `--agent_profiles`
- document new option in README

## Testing
- `python -m py_compile main.py generator/transactions.py`
- `python main.py --agent_profiles agents/agent_profiles.xlsx --output data/sample_output.xlsx --format xlsx --legit_txns 10 --laundering_chains 0`