### PR TITLE
Support cash BEnt entities

### DIFF
--- a/generator/transactions.py
+++ b/generator/transactions.py
@@ -136,6 +136,12 @@ def generate_profile_transactions(profile_df: pd.DataFrame, start_date: str, end
 
     merchants = profile_df[profile_df["type"] == "merchant"].copy()
     payers = profile_df[profile_df["type"].isin(["person", "company"])]
+    bent_df = profile_df[profile_df["type"] == "BEnt"]
+    bents_by_bank = {
+        str(bank): list(g["entity_id"]) for bank, g in bent_df.groupby("bank")
+    }
+
+    pending_deposits: dict[str, float] = {}
 
     transactions = []
 
@@ -202,20 +208,108 @@ def generate_profile_transactions(profile_df: pd.DataFrame, start_date: str, end
                 post_date = generate_post_date(ts_dt).strftime("%Y-%m-%d %H:%M:%S")
                 txn_id = generate_uuid()
 
-                entries = split_transaction(
-                    txn_id=txn_id,
-                    timestamp=timestamp,
-                    src=payer_acct,
-                    tgt=tgt_acct,
-                    amount=round(amount, 2),
-                    currency="USD",
-                    payment_type=payment_type,
-                    is_laundering=False,
-                    source_description=describe_transaction(payment_type, "Purchase"),
-                    known_accounts=known_accounts,
-                    post_date=post_date
-                )
+                amount = round(amount, 2)
 
-                transactions.extend(entries)
+                if payment_type == "cash":
+                    # Withdrawal by payer via BEnt
+                    payer_bank = str(payer.get("bank"))
+                    payer_bents = bents_by_bank.get(payer_bank, [])
+                    if payer_bents:
+                        bent_id = random.choice(payer_bents)
+                    else:
+                        bent_id = generate_uuid(8)
+
+                    entries = split_transaction(
+                        txn_id=txn_id + "W",
+                        timestamp=timestamp,
+                        src=payer_acct,
+                        tgt=None,
+                        amount=amount,
+                        currency="USD",
+                        payment_type="cash",
+                        is_laundering=False,
+                        known_accounts=known_accounts,
+                        post_date=post_date,
+                        atm_id=bent_id,
+                        atm_location=f"BEnt {bent_id} - Bank {payer_bank}"
+                    )
+                    transactions.extend(entries)
+
+                    deposit_now = random.choice([True, False])
+                    if deposit_now:
+                        merch_bank = str(merchant.get("bank"))
+                        merch_bents = bents_by_bank.get(merch_bank, [])
+                        bent2 = random.choice(merch_bents) if merch_bents else generate_uuid(8)
+                        entries = split_transaction(
+                            txn_id=txn_id + "D",
+                            timestamp=timestamp,
+                            src=None,
+                            tgt=tgt_acct,
+                            amount=amount,
+                            currency="USD",
+                            payment_type="cash",
+                            is_laundering=False,
+                            known_accounts=known_accounts,
+                            post_date=post_date,
+                            atm_id=bent2,
+                            atm_location=f"BEnt {bent2} - Bank {merch_bank}"
+                        )
+                        transactions.extend(entries)
+                    else:
+                        pending_deposits[tgt_acct.id] = pending_deposits.get(tgt_acct.id, 0) + amount
+                else:
+                    entries = split_transaction(
+                        txn_id=txn_id,
+                        timestamp=timestamp,
+                        src=payer_acct,
+                        tgt=tgt_acct,
+                        amount=amount,
+                        currency="USD",
+                        payment_type=payment_type,
+                        is_laundering=False,
+                        source_description=describe_transaction(payment_type, "Purchase"),
+                        known_accounts=known_accounts,
+                        post_date=post_date
+                    )
+                    transactions.extend(entries)
+
+    # Batch deposit accumulated cash for merchants/companies
+    for acct_id, amt in pending_deposits.items():
+        merchant_row = merchants[merchants["account_number"] == acct_id]
+        if merchant_row.empty:
+            continue
+        merchant = merchant_row.iloc[0]
+        merch_bank = str(merchant.get("bank"))
+        merch_bents = bents_by_bank.get(merch_bank, [])
+        bent_id = random.choice(merch_bents) if merch_bents else generate_uuid(8)
+
+        tgt_acct = ProfileAccount(
+            id=acct_id,
+            owner_id=merchant["entity_id"],
+            owner_type="Merchant",
+            owner_name=merchant.get("name", ""),
+            bank_name="",
+        )
+
+        ts_dt = generate_transaction_timestamp(start_dt, end_dt, entity_type="Company")
+        timestamp = ts_dt.strftime("%Y-%m-%d %H:%M:%S")
+        post_date = generate_post_date(ts_dt).strftime("%Y-%m-%d %H:%M:%S")
+        txn_id = generate_uuid()
+
+        entries = split_transaction(
+            txn_id=txn_id,
+            timestamp=timestamp,
+            src=None,
+            tgt=tgt_acct,
+            amount=round(amt, 2),
+            currency="USD",
+            payment_type="cash",
+            is_laundering=False,
+            known_accounts=known_accounts,
+            post_date=post_date,
+            atm_id=bent_id,
+            atm_location=f"BEnt {bent_id} - Bank {merch_bank}"
+        )
+        transactions.extend(entries)
 
     return transactions

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -37,8 +37,21 @@ def to_datetime(value):
     else:
         raise TypeError(f"Unsupported type for to_datetime: {type(value)}")
 
-def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_type, is_laundering,
-                      source_description="", known_accounts=None, post_date=None):
+def split_transaction(
+    txn_id,
+    timestamp,
+    src,
+    tgt,
+    amount,
+    currency,
+    payment_type,
+    is_laundering,
+    source_description="",
+    known_accounts=None,
+    post_date=None,
+    atm_id=None,
+    atm_location=None,
+):
     """Split a transaction into debit and credit entries."""
     known_accounts = known_accounts or set()
     rows = []
@@ -61,12 +74,16 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
     debit_description = f"{payment_type.upper()} - {recipient_name}"
 
     if payment_type.lower() == "cash":
-        # Simulated ATM metadata
-        atm_name = fake.company()
-        atm_address = fake.address().replace("\n", ", ")
-        atm_id = generate_uuid(8)
-        credit_description = f"CASH - Deposit at {atm_name} ATM ({atm_address})"
-        debit_description = f"CASH - Withdrawal at {atm_name} ATM ({atm_address})"
+        # Use provided ATM/BEnt metadata if available
+        if atm_id is None:
+            atm_id = generate_uuid(8)
+        if atm_location is None:
+            atm_name = fake.company()
+            atm_address = fake.address().replace("\n", ", ")
+            atm_location = f"{atm_name} ({atm_address})"
+
+        credit_description = f"CASH - Deposit at {atm_location}"
+        debit_description = f"CASH - Withdrawal at {atm_location}"
 
         placeholder_cp = "ATM"
 
@@ -89,7 +106,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
                     "source_description": credit_description,
                     "post_date": post_date,
                     "atm_id": atm_id,
-                    "atm_location": atm_address
+                    "atm_location": atm_location
                 })
             return rows
 
@@ -112,7 +129,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
                     "source_description": debit_description,
                     "post_date": post_date,
                     "atm_id": atm_id,
-                    "atm_location": atm_address
+                    "atm_location": atm_location
                 })
             return rows
 
@@ -134,7 +151,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
                 "source_description": debit_description,
                 "post_date": post_date,
                 "atm_id": atm_id,
-                "atm_location": atm_address
+                "atm_location": atm_location
             })
 
         if tgt_known:
@@ -154,7 +171,7 @@ def split_transaction(txn_id, timestamp, src, tgt, amount, currency, payment_typ
                 "source_description": credit_description,
                 "post_date": post_date,
                 "atm_id": atm_id,
-                "atm_location": atm_address
+                "atm_location": atm_location
             })
 
         return rows


### PR DESCRIPTION
## Summary
- extend `split_transaction` to allow pre-specified BEnt metadata
- generate cash withdrawals and deposits via BEnt in profile-based transactions
- batch cash deposits for merchants during business hours

## Testing
- `python -m py_compile utils/helpers.py generator/transactions.py`
- `pytest -q`