### PR TITLE
Implement ATM cash amount rounding

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This project generates small-scale, realistic anti-money laundering (AML) datase
 - Simulate common laundering patterns such as fan-out, cycles, and scatter-gather.
 - Label laundering transactions for easy classification.
 - Export clean `.csv` or `.xlsx` files for Excel.
+- ATM cash transactions are rounded to the nearest $20.
 
 ---
 

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -37,6 +37,10 @@ def to_datetime(value):
     else:
         raise TypeError(f"Unsupported type for to_datetime: {type(value)}")
 
+def round_cash_amount(amount: float) -> int:
+    """Round a cash amount to the nearest $20 as an integer."""
+    return int(round(float(amount) / 20.0)) * 20
+
 def split_transaction(
     txn_id,
     timestamp,
@@ -76,6 +80,7 @@ def split_transaction(
             credit_description = f"ACH Transfer - {abs(amount):.2f} - {src_name}"
 
     if payment_type.lower() == "cash":
+        amount = round_cash_amount(amount)
         # Use provided ATM/BEnt metadata if available
         if atm_id is None:
             atm_id = generate_uuid(8)


### PR DESCRIPTION
## Summary
- round cash amounts to nearest $20 in `split_transaction`
- document ATM rounding in the README

## Testing
- `python -m py_compile utils/helpers.py`

------
https://chatgpt.com/codex/tasks/task_b_684720ae21c483328174bd2c2b7beee7