### PR TITLE
Enhance cash transaction realism

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,11 @@ This project generates small-scale, realistic anti-money laundering (AML) datase
 - Label laundering transactions for easy classification.
 - Export clean `.csv` or `.xlsx` files for Excel.
 - Cash transactions now include a `channel` field (`ATM` or `Teller`). Amounts
-  handled at an ATM are rounded to the nearest $20 and limited to $500.
+  handled at an ATM are rounded to the nearest $20 and limited to $500. When a
+  transaction is selected as cash, the base amount is divided by a random value
+  between 2 and 5 to reflect everyday spending. If the result still exceeds $500,
+  the generator creates multiple ATM withdrawals (5% chance) or a single teller
+  transaction (95% chance), unless overridden by a laundering pattern.
 - Descriptions for merchant purchases now leverage an NLP-based model to
   infer the transaction type from NAICS codes and whether the payer is a person
   or company. Each NAICS category includes multiple description options and the
@@ -81,5 +85,5 @@ The generator will read merchant patterns, frequencies, payment methods, and ave
 
 ### BEnt Entities (ATMs/Tellers)
 `BEnt` rows in the agent profiles represent bank entities such as ATMs or teller locations. They provide the IDs and addresses used when cash withdrawals and deposits occur. Be sure to include them in the profile data so cash transactions can reference the correct location. If no `BEnt` information is provided, the generator will create placeholder ATMs.
-ATM withdrawals are limited to $500 while tellers can handle larger amounts in laundering patterns.
+ATM withdrawals are limited to $500. When cash needs exceed this limit, the generator usually records a teller transaction but will occasionally split the amount into several ATM withdrawals. Laundering patterns may override these rules.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This project generates small-scale, realistic anti-money laundering (AML) datase
 - Simulate common laundering patterns such as fan-out, cycles, and scatter-gather.
 - Label laundering transactions for easy classification.
 - Export clean `.csv` or `.xlsx` files for Excel.
-- ATM cash transactions are rounded to the nearest $20.
+- Cash transactions now include a `channel` field (`ATM` or `Teller`). Amounts
+  handled at an ATM are rounded to the nearest $20 and limited to $500.
 - Descriptions for merchant purchases now leverage an NLP-based model to
   infer the transaction type from NAICS codes and whether the payer is a person
   or company. Each NAICS category includes multiple description options and the
@@ -47,13 +48,27 @@ The patterns.yaml file contains the instructions for each money laundering techn
 
 | Field                     | Description                                                                                         |
 | ------------------------- | --------------------------------------------------------------------------------------------------- |
-| `type`                    | Type of laundering pattern (`cycle`, `fan_out`, `fan_in`, `scatter_gather`, `gather_scatter`, etc.) |
+| `type`                    | Type of laundering pattern (`cycle`, `fan_out`, `fan_in`, `scatter_gather`, `gather_scatter`, `cash_structuring`, etc.) |
 | `instances`               | How many times to inject this pattern                                                               |
 | `amount` / `total_amount` | Total amount to launder or per transaction                                                          |
 | `accounts_per_*`          | How many accounts are involved (varies by pattern)                                                  |
 | `currency`                | Optional override from default                                                                      |
 | `start_date`, `end_date`  | Timestamp range to assign to transactions                                                           |
 | `label`                   | Whether transactions should be marked as laundering                                                 |
+
+Example `cash_structuring` pattern:
+
+```yaml
+  - type: cash_structuring
+    instances: 1
+    accounts: 2
+    transactions_per_account: 5
+    max_deposit: 10000
+    atm_ratio: 0.6
+    start_date: "2025-01-21"
+    end_date: "2025-01-25"
+    label: true
+```
 
 ### Agent Profiles
 If you have a structured Excel file of agent profiles, you can generate transactions based on that data:
@@ -66,4 +81,5 @@ The generator will read merchant patterns, frequencies, payment methods, and ave
 
 ### BEnt Entities (ATMs/Tellers)
 `BEnt` rows in the agent profiles represent bank entities such as ATMs or teller locations. They provide the IDs and addresses used when cash withdrawals and deposits occur. Be sure to include them in the profile data so cash transactions can reference the correct location. If no `BEnt` information is provided, the generator will create placeholder ATMs.
+ATM withdrawals are limited to $500 while tellers can handle larger amounts in laundering patterns.
 

--- a/config/patterns.yaml
+++ b/config/patterns.yaml
@@ -28,6 +28,17 @@ patterns:
     end_date: "2025-01-20"
     label: true
 
+  - type: cash_structuring
+    instances: 1
+    accounts: 2
+    transactions_per_account: 5
+    max_deposit: 10000
+    atm_ratio: 0.6
+    currency: USD
+    start_date: "2025-01-21"
+    end_date: "2025-01-25"
+    label: true
+
 defaults:
   currency: USD
   label: true

--- a/generator/transactions.py
+++ b/generator/transactions.py
@@ -163,7 +163,7 @@ def generate_legit_transactions(accounts, entities, n=1000, start_date="2025-01-
                 if random.random() < 0.05:
                     remaining = amount
                     part_idx = 0
-                    while remaining > 0:
+                    while round(remaining, 2) > 0:
                         part = round(min(ATM_LIMIT, remaining), 2)
                         part_id = f"{txn_id}-{part_idx}"
                         entries = split_transaction(
@@ -388,7 +388,7 @@ def generate_profile_transactions(
                         if random.random() < 0.05:
                             remaining = amount
                             idx = 0
-                            while remaining > 0:
+                            while round(remaining, 2) > 0:
                                 part = round(min(ATM_LIMIT, remaining), 2)
                                 w_id = f"{txn_id}W{idx}"
                                 entries = split_transaction(

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -117,6 +117,7 @@ def split_transaction(
     post_date=None,
     atm_id=None,
     atm_location=None,
+    channel="ATM",
 ):
     """Split a transaction into debit and credit entries."""
     known_accounts = known_accounts or set()
@@ -189,7 +190,8 @@ def split_transaction(
         )
 
     if payment_type.lower() == "cash":
-        amount = round_cash_amount(amount)
+        if channel == "ATM":
+            amount = round_cash_amount(amount)
         # Use provided ATM/BEnt metadata if available
         if atm_id is None:
             atm_id = generate_uuid(8)
@@ -201,7 +203,7 @@ def split_transaction(
         credit_description = f"CASH - Deposit at {atm_location}"
         debit_description = f"CASH - Withdrawal at {atm_location}"
 
-        placeholder_cp = "ATM"
+        placeholder_cp = channel
 
         # Deposit: src is None
         if src is None and tgt is not None:
@@ -223,7 +225,8 @@ def split_transaction(
                     "post_date": post_date,
                     "atm_id": atm_id,
                     "atm_location": atm_location,
-                    "wire_details": wire_details
+                    "wire_details": wire_details,
+                    "channel": channel
                 })
             return rows
 
@@ -247,7 +250,8 @@ def split_transaction(
                     "post_date": post_date,
                     "atm_id": atm_id,
                     "atm_location": atm_location,
-                    "wire_details": wire_details
+                    "wire_details": wire_details,
+                    "channel": channel
                 })
             return rows
 
@@ -270,7 +274,8 @@ def split_transaction(
                 "post_date": post_date,
                 "atm_id": atm_id,
                 "atm_location": atm_location,
-                "wire_details": wire_details
+                "wire_details": wire_details,
+                "channel": channel
             })
 
         if tgt_known:
@@ -291,7 +296,8 @@ def split_transaction(
                 "post_date": post_date,
                 "atm_id": atm_id,
                 "atm_location": atm_location,
-                "wire_details": wire_details
+                "wire_details": wire_details,
+                "channel": channel
             })
 
         return rows


### PR DESCRIPTION
## Summary
- add `channel` parameter to `split_transaction` to distinguish ATM vs. Teller
- limit legitimate cash amounts to ATM_LIMIT and set channel in transaction generation
- implement `cash_structuring` laundering pattern
- update example pattern configuration
- document cash channel field, ATM limits, and cash_structuring pattern in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6849d40a6548833289b7f13d8d1013c5