### PR TITLE
Limit laundering accounts to agents with legitimate history

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ This project generates small-scale, realistic anti-money laundering (AML) datase
 - Generate financial transactions with realistic timestamps, payment types, and currencies.
 - Simulate common laundering patterns such as fan-out, cycles, and scatter-gather.
 - Label laundering transactions for easy classification.
+- Laundering participants are selected from agents with legitimate activity so no
+  new accounts appear only in laundering transactions.
 - Export clean `.csv` or `.xlsx` files for Excel.
 - Cash transactions now include a `channel` field (`ATM` or `Teller`). Amounts
   handled at an ATM are rounded to the nearest $20 and limited to $500. When a

--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ This project generates small-scale, realistic anti-money laundering (AML) datase
 - Label laundering transactions for easy classification.
 - Laundering participants are selected from agents with legitimate activity so no
   new accounts appear only in laundering transactions.
+- Legitimate transactions that occur before an account participates in
+  laundering remain untainted when labels propagate.
 - Export clean `.csv` or `.xlsx` files for Excel.
 - Cash transactions now include a `channel` field (`ATM` or `Teller`). Amounts
   handled at an ATM are rounded to the nearest $20 and limited to $500. When a


### PR DESCRIPTION
## Summary
- restrict laundering transaction generation to only use agents that already appear in legitimate transactions
- document that laundering participants come from agents with legitimate activity

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684a06a7160083328a2b6bd864a5d314