### PR TITLE
Add flake8 and basic lint instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,14 @@ source aml-env/bin/activate
 pip3 install -r requirements.txt
 ```
 
+### Linting
+
+Run flake8 to check code style:
+
+```bash
+flake8
+```
+
 # Files
 ### Patterns.yaml
 The patterns.yaml file contains the instructions for each money laundering technique.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Faker==37.1.0
 openpyxl==3.1.5
 pyyaml==6.0.1
 streamlit==1.32.2
+flake8


### PR DESCRIPTION
## Summary
- include `flake8` in requirements
- document how to run linting with flake8

## Testing
- `python -m pip install flake8` *(fails: tunnel connection failed)*
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684af5cf46c0833297627e91c1cc9501