### PR TITLE
Update laundering account flags

### DIFF
--- a/generator/labels.py
+++ b/generator/labels.py
@@ -1,7 +1,14 @@
 from collections import defaultdict
 
 def flag_laundering_accounts(entries, accounts, entities=None):
-    """Mark Account and Entity objects participating in laundering."""
+    """Mark Account and Entity objects participating in laundering.
+
+    In addition to flagging the ``Account`` and ``Entity`` instances, any
+    transaction entry whose ``account_id`` matches a flagged account will have
+    ``"laundering_account"`` set to ``"Yes"``. This ensures that both the debit
+    and credit sides of the transaction reflect the updated status.
+    """
+
     laundering_ids = {e["account_id"] for e in entries if e.get("is_laundering")}
     acct_map = {a.id: a for a in accounts}
 
@@ -14,6 +21,11 @@ def flag_laundering_accounts(entries, accounts, entities=None):
             for ent in entities:
                 if acct in getattr(ent, "accounts", []):
                     ent.launderer = True
+
+    # Update all entries to reflect flagged accounts
+    for entry in entries:
+        if entry.get("account_id") in laundering_ids:
+            entry["laundering_account"] = "Yes"
 
 def propagate_laundering(entries):
     """Propagate laundering labels based on transaction chronology.

--- a/tests/test_labels.py
+++ b/tests/test_labels.py
@@ -4,7 +4,9 @@ import pytest
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
-from generator.labels import propagate_laundering
+from types import SimpleNamespace
+
+from generator.labels import propagate_laundering, flag_laundering_accounts
 
 
 def test_propagate_laundering_respects_first_event():
@@ -45,3 +47,24 @@ def test_propagate_laundering_respects_first_event():
     assert result[1]["is_laundering"] is True
     assert result[2]["is_laundering"] is True
     assert result[3]["is_laundering"] is True
+
+
+def test_flag_laundering_accounts_updates_entries():
+    entries = [
+        {"account_id": "A", "is_laundering": True, "direction": "debit"},
+        {"account_id": "B", "is_laundering": True, "direction": "credit"},
+        {"account_id": "B", "is_laundering": False, "direction": "debit"},
+    ]
+
+    accounts = [
+        SimpleNamespace(id="A", launderer=False),
+        SimpleNamespace(id="B", launderer=False),
+    ]
+
+    flag_laundering_accounts(entries, accounts)
+
+    for entry in entries:
+        assert entry.get("laundering_account") == "Yes"
+
+    for acct in accounts:
+        assert acct.launderer is True


### PR DESCRIPTION
## Summary
- mark laundering accounts in `flag_laundering_accounts`
- add new tests verifying that entries get flagged

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684b1939c6588332936c4d35e48dac76