### PR TITLE
Ensure transaction amounts are absolute

### DIFF
--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,42 @@
+import os
+import sys
+from types import SimpleNamespace
+
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from utils.helpers import split_transaction
+
+
+def test_split_transaction_amounts_are_absolute():
+    src = SimpleNamespace(
+        id="A",
+        bank_name="Bank",
+        owner_name="Alice",
+        owner_type="Individual",
+        bank="001",
+        bank_code="001",
+        launderer=False,
+    )
+    tgt = SimpleNamespace(
+        id="B",
+        bank_name="Bank",
+        owner_name="Bob",
+        owner_type="Individual",
+        bank="001",
+        bank_code="001",
+        launderer=False,
+    )
+
+    entries = split_transaction(
+        txn_id="T1",
+        timestamp="2025-01-01 10:00:00",
+        src=src,
+        tgt=tgt,
+        amount=-123.45,
+        currency="USD",
+        payment_type="ach",
+        is_laundering=False,
+        known_accounts={"A", "B"},
+    )
+
+    assert all(e["amount"] >= 0 for e in entries)

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -137,6 +137,7 @@ def split_transaction(
     """Split a transaction into debit and credit entries."""
     known_accounts = known_accounts or set()
     rows = []
+    amount = abs(amount)
 
     src_known = src is not None and hasattr(src, "id") and src.id in known_accounts
     tgt_known = tgt is not None and hasattr(tgt, "id") and tgt.id in known_accounts
@@ -229,7 +230,7 @@ def split_transaction(
                     "timestamp": timestamp,
                     "account_id": tgt.id,
                     "counterparty": placeholder_cp,
-                    "amount": abs(amount),
+                    "amount": amount,
                     "direction": "credit",
                     "currency": currency,
                     "bank_name": tgt.bank_name,
@@ -257,7 +258,7 @@ def split_transaction(
                     "timestamp": timestamp,
                     "account_id": src.id,
                     "counterparty": placeholder_cp,
-                    "amount": -abs(amount),
+                    "amount": amount,
                     "direction": "debit",
                     "currency": currency,
                     "bank_name": src.bank_name,
@@ -284,7 +285,7 @@ def split_transaction(
                 "timestamp": timestamp,
                 "account_id": src.id,
                 "counterparty": tgt.id if tgt else placeholder_cp,
-                "amount": -abs(amount),
+                "amount": amount,
                 "direction": "debit",
                 "currency": currency,
                 "bank_name": src.bank_name,
@@ -309,7 +310,7 @@ def split_transaction(
                 "timestamp": timestamp,
                 "account_id": tgt.id,
                 "counterparty": src.id if src else placeholder_cp,
-                "amount": abs(amount),
+                "amount": amount,
                 "direction": "credit",
                 "currency": currency,
                 "bank_name": tgt.bank_name,
@@ -337,7 +338,7 @@ def split_transaction(
             "timestamp": timestamp,
             "account_id": src.id,
             "counterparty": tgt.id,
-            "amount": -abs(amount),
+            "amount": amount,
             "direction": "debit",
             "currency": currency,
             "bank_name": src.bank_name,
@@ -359,7 +360,7 @@ def split_transaction(
             "timestamp": timestamp,
             "account_id": tgt.id,
             "counterparty": src.id if src else "",
-            "amount": abs(amount),
+            "amount": amount,
             "direction": "credit",
             "currency": currency,
             "bank_name": tgt.bank_name,
@@ -381,7 +382,7 @@ def split_transaction(
             "timestamp": timestamp,
             "account_id": src.id,
             "counterparty": "",
-            "amount": -25.0,
+            "amount": 25.0,
             "direction": "debit",
             "currency": currency,
             "bank_name": src.bank_name,


### PR DESCRIPTION
## Summary
- Normalize amounts in `split_transaction` to always store positive values, including wire fees
- Add regression test confirming split_transaction returns non-negative amounts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_6895230c1618833282e2c2635fd24246